### PR TITLE
fix: resolve TailwindCSS CLI not found error in production builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,6 +75,21 @@ jobs:
         run: |
           npm ci
           echo "Node.js dependencies installed successfully"
+          
+      - name: Verify TailwindCSS CLI installation
+        run: |
+          echo "Verifying TailwindCSS CLI installation..."
+          ./node_modules/.bin/tailwindcss --version
+          which tailwindcss || echo "tailwindcss not in global PATH"
+          
+      - name: Create TailwindCSS global symlink
+        run: |
+          echo "Creating global symlink for TailwindCSS CLI..."
+          sudo ln -sf "$(pwd)/node_modules/.bin/tailwindcss" /usr/local/bin/tailwindcss
+          sudo chmod +x /usr/local/bin/tailwindcss
+          tailwindcss --version
+          echo "Verifying npx can find tailwindcss..."
+          npx tailwindcss --version
 
       - name: Cache Hugo modules
         uses: actions/cache@v4
@@ -88,7 +103,8 @@ jobs:
         if: github.ref != 'refs/heads/main'
         run: |
           echo "Building for development environment..."
-          export PATH="./node_modules/.bin:$PATH"
+          echo "PATH: $PATH"
+          echo "TailwindCSS location: $(which tailwindcss)"
           HUGO_ENV=development npm run build:development
           echo "Development build completed"
 
@@ -96,7 +112,8 @@ jobs:
         if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: |
           echo "Building for production environment..."
-          export PATH="./node_modules/.bin:$PATH"
+          echo "PATH: $PATH"
+          echo "TailwindCSS location: $(which tailwindcss)"
           HUGO_ENV=production npm run build:production
           echo "Production build completed"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,14 @@ hugo new posts/my-new-post.md
 3. Clean build artifacts: `npm run clean`
 4. Rebuild: `npm run build:development`
 
+### TailwindCSS CLI Issues
+**Problem**: `binary with name "tailwindcss" not found using npx`
+**Cause**: Hugo's `css.TailwindCSS` function with `minify: true` requires TailwindCSS CLI to be accessible via `npx`
+**Solution**: The CI/CD pipeline automatically creates a global symlink for TailwindCSS CLI
+- In CI: `sudo ln -sf $(pwd)/node_modules/.bin/tailwindcss /usr/local/bin/tailwindcss`
+- Local development: Ensure TailwindCSS is globally installed or use `npm run dev`
+- Verification: `npx tailwindcss --version` should work
+
 ### Deployment Issues  
 1. Verify Wrangler authentication: `wrangler whoami`
 2. Test deployment configuration: `npm run deploy:dry-run`

--- a/scripts/build-assets.sh
+++ b/scripts/build-assets.sh
@@ -89,6 +89,24 @@ if [ -f "package.json" ]; then
     fi
 fi
 
+# Verify TailwindCSS CLI availability
+echo -e "${BLUE}🎨 Verifying TailwindCSS CLI...${NC}"
+if command_exists tailwindcss; then
+    echo -e "${GREEN}✅ TailwindCSS CLI found: $(which tailwindcss)${NC}"
+    tailwindcss --version
+elif [ -f "./node_modules/.bin/tailwindcss" ]; then
+    echo -e "${GREEN}✅ TailwindCSS CLI found in node_modules${NC}"
+    ./node_modules/.bin/tailwindcss --version
+    if [ "$CI" = "true" ]; then
+        echo "Adding node_modules/.bin to PATH for CI environment"
+        export PATH="$(pwd)/node_modules/.bin:$PATH"
+    fi
+else
+    echo -e "${RED}❌ TailwindCSS CLI not found${NC}"
+    echo "Please ensure TailwindCSS is installed: npm install -D tailwindcss @tailwindcss/cli"
+    exit 1
+fi
+
 # Generate Chroma CSS files for syntax highlighting if they don't exist
 echo -e "${BLUE}🎨 Generating syntax highlighting CSS...${NC}"
 


### PR DESCRIPTION
- Add global symlink creation for TailwindCSS CLI in CI environment
- Enhance build script with TailwindCSS CLI verification and fallback
- Remove ineffective PATH exports and add proper debugging output
- Update documentation with troubleshooting guide for TailwindCSS CLI issues
- Ensure Hugo's css.TailwindCSS function can find tailwindcss via npx in production