### PR TITLE
fix: resolve TailwindCSS v4 CLI compatibility with Hugo production bu…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,14 @@ jobs:
         # 在生产构建时，将 PRODUCTION_URL 环境变量传递给构建脚本
         run: |
           npm ci
+          # Fix TailwindCSS v4 CLI compatibility - Hugo's css.TailwindCSS expects 'tailwindcss' command
+          # Create symlink from @tailwindcss/cli to tailwindcss for npx compatibility
+          if [ -f "node_modules/.bin/@tailwindcss/cli" ]; then
+            echo "Creating TailwindCSS CLI symlink for Hugo compatibility..."
+            ln -sf @tailwindcss/cli node_modules/.bin/tailwindcss
+          else
+            echo "Warning: @tailwindcss/cli not found - TailwindCSS CLI may not work"
+          fi
           if [[ "${{ github.ref }}" == "refs/heads/main" || \
                 ( "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.environment }}" == "production" ) ]]; then
             echo "Building for production..."

--- a/scripts/build-assets.sh
+++ b/scripts/build-assets.sh
@@ -97,6 +97,14 @@ fi
 # Verifying TailwindCSS CLI...
 echo -e "${BLUE}🎨 Verifying TailwindCSS CLI...${NC}"
 TAILWIND_CLI_PATH="./node_modules/.bin/tailwindcss"
+TAILWIND_V4_CLI_PATH="./node_modules/.bin/@tailwindcss/cli"
+
+# Fix TailwindCSS v4 CLI compatibility - Hugo's css.TailwindCSS expects 'tailwindcss' command
+if [ -f "$TAILWIND_V4_CLI_PATH" ] && [ ! -f "$TAILWIND_CLI_PATH" ]; then
+    echo -e "${YELLOW}📝 TailwindCSS v4 detected - creating CLI symlink for Hugo compatibility${NC}"
+    ln -sf @tailwindcss/cli "./node_modules/.bin/tailwindcss"
+    echo -e "${GREEN}✅ Created symlink: @tailwindcss/cli -> tailwindcss${NC}"
+fi
 
 if [ -f "$TAILWIND_CLI_PATH" ]; then
     echo -e "${GREEN}✅ TailwindCSS CLI found locally: $TAILWIND_CLI_PATH${NC}"


### PR DESCRIPTION
…ilds

- **Root Cause**: TailwindCSS v4 moved CLI to @tailwindcss/cli package, breaking Hugo's css.TailwindCSS function in production (minify: true)
- **Environment Impact**: Development builds work (minify: false), production builds fail (minify: true)
- **CI/CD Fix**: Auto-create symlink @tailwindcss/cli -> tailwindcss after npm ci
- **Local Fix**: Auto-detect and create symlink in build-assets.sh
- **Documentation**: Updated CLAUDE.md with comprehensive troubleshooting guide

This resolves the "binary with name 'tailwindcss' not found" error in production deployments while maintaining staging/development functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)