### PR TITLE
fix: correct theme toggle icon logic

### DIFF
--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -282,8 +282,10 @@ class ThemeSwitcher {
       const moonIcon = toggleButton.querySelector('.moon-icon');
       
       if (sunIcon && moonIcon) {
-        sunIcon.classList.toggle('hidden', isDark);
-        moonIcon.classList.toggle('hidden', !isDark);
+        // Show moon icon in light mode (to indicate switching to dark)
+        // Show sun icon in dark mode (to indicate switching to light)
+        moonIcon.classList.toggle('hidden', isDark);
+        sunIcon.classList.toggle('hidden', !isDark);
       }
       
       // Update pressed state for screen readers

--- a/layouts/_partials/theme-toggle.html
+++ b/layouts/_partials/theme-toggle.html
@@ -20,8 +20,8 @@
   onmouseout="this.style.backgroundColor='transparent'; this.style.borderColor='var(--color-border)';"
 >
   <svg style="width: 1.25rem; height: 1.25rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" role="img">
-    <path class="sun-icon" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
-    <path class="moon-icon hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+    <path class="moon-icon" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+    <path class="sun-icon hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
   </svg>
   <span class="sr-only">Current theme: <span class="theme-status">light</span></span>
 </button>


### PR DESCRIPTION
- Fix icon display logic: show moon in light mode, sun in dark mode
- Update HTML template to default moon icon visible, sun hidden
- Update JavaScript logic to properly toggle icon visibility
- Icons now correctly indicate the mode user will switch TO, not current mode