### PR TITLE
fix: update production URL from hugo-overreacted-blog.workers.dev to …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Multi-job pipeline:
 
 ### Required Variables
 - `STAGING_URL` - Staging environment URL (e.g., `https://hugo-overreacted-blog-staging.zjlgdx.workers.dev`)
-- `PRODUCTION_URL` - Production environment URL (e.g., `https://hugo-overreacted-blog.workers.dev`)
+- `PRODUCTION_URL` - Production environment URL (e.g., `https://hugo-overreacted-blog-prod.zjlgdx.workers.dev`)
 
 **Note**: Set these variables in GitHub repository Settings → Secrets and variables → Actions → Variables tab.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run build:prod
 
 ## Live Demo
 
-- **Production:** https://hugo-overreacted-blog.workers.dev/
+- **Production:** https://hugo-overreacted-blog-prod.zjlgdx.workers.dev/
 - **Staging:** https://hugo-overreacted-blog-staging.zjlgdx.workers.dev/
 
 ## Documentation
@@ -99,4 +99,4 @@ Inspired by [overreacted.io](https://overreacted.io/) by Dan Abramov.
 
 ---
 
-**[Live Demo](https://hugo-overreacted-blog.workers.dev/)** • **[Documentation](docs/)** • **[Issues](https://github.com/YYvanYang/hugo-overreacted-blog/issues)**
+**[Live Demo](https://hugo-overreacted-blog-prod.zjlgdx.workers.dev/)** • **[Documentation](docs/)** • **[Issues](https://github.com/YYvanYang/hugo-overreacted-blog/issues)**

--- a/docs/development/cicd-optimization.md
+++ b/docs/development/cicd-optimization.md
@@ -243,7 +243,7 @@ env:
   GO_VERSION: "1.21"
   STAGING_URL: "https://hugo-overreacted-blog-staging.zjlgdx.workers.dev"
   # ⚠️ 重要: 请在项目上线时将此 URL 替换为您的真实生产域名
-  PRODUCTION_URL: "https://hugo-overreacted-blog.workers.dev"
+  PRODUCTION_URL: "https://hugo-overreacted-blog-prod.zjlgdx.workers.dev"
 
 jobs:
   # 1. 构建作业

--- a/docs/technical/build-automation.md
+++ b/docs/technical/build-automation.md
@@ -53,7 +53,7 @@ The workflow is triggered by:
 - **Runs on**: `main` branch or manual dispatch (production)
 - **Purpose**: Deploy to production environment
 - **Environment**: `production`
-- **URL**: `https://hugo-overreacted-blog.workers.dev`
+- **URL**: `https://hugo-overreacted-blog-prod.zjlgdx.workers.dev`
 - **Steps**:
   - Download build artifacts
   - Deploy using Wrangler CLI
@@ -200,7 +200,7 @@ CI=true GITHUB_ACTIONS=true ./scripts/test-system.sh
 SITE_URL="https://hugo-overreacted-blog-staging.zjlgdx.workers.dev" ./scripts/test-deployment.sh
 
 # Test production deployment
-SITE_URL="https://hugo-overreacted-blog.workers.dev" ./scripts/test-deployment.sh
+SITE_URL="https://hugo-overreacted-blog-prod.zjlgdx.workers.dev" ./scripts/test-deployment.sh
 
 # Generate detailed report
 ./scripts/test-deployment.sh --report
@@ -299,7 +299,7 @@ Key configurations:
 ### Production Environment
 - **Hugo Environment**: `production`
 - **Cloudflare Environment**: `production`
-- **URL**: `https://hugo-overreacted-blog.workers.dev`
+- **URL**: `https://hugo-overreacted-blog-prod.zjlgdx.workers.dev`
 - **Features**: Full optimization, minification, compression
 
 ## Performance Optimizations

--- a/docs/technical/deployment.md
+++ b/docs/technical/deployment.md
@@ -35,7 +35,7 @@ Your site will be available at: `https://hugo-overreacted-blog-staging.zjlgdx.wo
 
 ### Development
 - **Command**: `npm run deploy`
-- **URL**: `https://hugo-overreacted-blog.workers.dev`
+- **URL**: `https://hugo-overreacted-blog-prod.zjlgdx.workers.dev`
 - **Use**: Local testing and development
 
 ### Staging

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -95,7 +95,7 @@ esac
 if [ "$ENVIRONMENT" = "production" ]; then
     export HUGO_ENV=production
     export NODE_ENV=production
-    EXPECTED_URL="https://hugo-overreacted-blog.workers.dev"
+    EXPECTED_URL="https://hugo-overreacted-blog-prod.zjlgdx.workers.dev"
 else
     export HUGO_ENV=development
     export NODE_ENV=development

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -48,7 +48,7 @@ watch_dir = ["content", "layouts", "assets", "static", "hugo.toml"]
 # Variables for different environments
 [vars]
 ENVIRONMENT = "development"
-SITE_URL = "https://hugo-overreacted-blog.workers.dev"
+SITE_URL = "https://hugo-overreacted-blog-prod.zjlgdx.workers.dev"
 
 [env.production.vars]
 ENVIRONMENT = "production"


### PR DESCRIPTION
…hugo-overreacted-blog-prod.zjlgdx.workers.dev

- update README.md live demo links and footer navigation
- update CLAUDE.md production URL example
- update wrangler.toml development SITE_URL variable
- update scripts/deploy.sh production environment expected URL
- update documentation files:
  * docs/development/cicd-optimization.md
  * docs/technical/deployment.md
  * docs/technical/build-automation.md (multiple occurrences)

Ensures consistency across all project references to production deployment URL. Maintains staging URL unchanged at hugo-overreacted-blog-staging.zjlgdx.workers.dev.

🤖 Generated with [Claude Code](https://claude.ai/code)