### PR TITLE
fix: ensure GitHub Actions environment URLs have proper https:// prot…

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -24,7 +24,7 @@ jobs:
     name: Deploy to ${{ inputs.environment_name }}
     environment:
       name: ${{ inputs.environment_name }}
-      url: ${{ inputs.environment_url }}
+      url: ${{ startsWith(inputs.environment_url, 'http') && inputs.environment_url || format('https://{0}', inputs.environment_url) }}
     
     steps:
       - name: Checkout repository
@@ -50,6 +50,11 @@ jobs:
           echo "Waiting 15s for deployment to propagate..."
           sleep 15
           
-          echo "Running validation tests on ${{ inputs.environment_url }}"
-          # 将 SITE_URL 环境变量传递给测试脚本
-          SITE_URL=${{ inputs.environment_url }} ./scripts/test-deployment.sh
+          # Ensure URL has https:// protocol
+          URL="${{ inputs.environment_url }}"
+          if [[ ! "$URL" =~ ^https?:// ]]; then
+            URL="https://$URL"
+          fi
+          
+          echo "Running validation tests on $URL"
+          SITE_URL="$URL" ./scripts/test-deployment.sh


### PR DESCRIPTION
…ocol

- add automatic https:// prefix to environment URLs if missing
- fix GitHub Actions validation error: 'Environment URL is not a valid http(s) URL'
- improve URL handling in deployment validation step
- ensure environment URLs display correctly in workflow graph

This resolves the issue where GitHub repository variables containing URLs without protocol prefixes (e.g., 'hugo-overreacted-blog-prod.zjlgdx.workers.dev') would fail GitHub Actions environment URL validation.

🤖 Generated with [Claude Code](https://claude.ai/code)